### PR TITLE
Highlight with uppercase letters

### DIFF
--- a/core/common.sh
+++ b/core/common.sh
@@ -156,8 +156,10 @@ usage() {
     echo "                        only (for details see section 4 inside the"
     echo "                        documentation file)"
     echo "  -h, --help            print this help message and exit"
-    echo "  --highlight           highlight the filter terms (by inverting"\
-                                 "their colors)"
+    echo "  --highlight           highlight the filter terms by inverting"\
+                                 "their colors"
+    echo "  --highlight-upper     Same as '--highlight' with uppercase"\
+                                 "letters"
     echo "  --ignore-case         ignore the case of the given filter pattern"
     echo "  --no-info             do not display the information header and"\
                                  "footer"

--- a/core/global.sh
+++ b/core/global.sh
@@ -49,6 +49,7 @@ set_global_variables() {
     follow=1
     header=1
     highlight=0
+    highlight_upper=0
     prompt=0
     slow=0
     wait_match=0

--- a/core/output.sh
+++ b/core/output.sh
@@ -226,7 +226,7 @@ print_output_line() {
 
     output="${color_code}${line}${color_none}"
     if [ "$filter_list" != "" ]; then
-        if [ $highlight $op 1 ]; then
+        if [ $highlight $op 1 ] || [ $highlight_upper $op 1 ]; then
             if [ $color_match $op 1 ]; then
                 color_high=$(echo "$color_code" | sed -e "s/0;/7;/g" \
                                                 | sed -e "s/1;/7;/g")
@@ -246,10 +246,15 @@ print_output_line() {
 
                 echo "$line" | grep $arg_case "$term" &>/dev/null
                 if [ $? $op 0 ]; then
-                    temp=$(echo $em "${color_high}${term_upper}${color_none}"\
+                    if [ $highlight_upper $op 1 ]; then
+                        term_case=$term_upper
+                    else
+                        term_case=$term
+                    fi
+                    temp=$(echo $em "${color_high}${term_case}${color_none}"\
                                     "${bs}${color_code}")
                     output=$(echo $em "${color_code}${line}${color_none}" \
-                            | sed -e "s/$term_upper/$temp/ig")
+                            | sed -e "s/$term_case/$temp/ig")
                     filter_match=1
                     break
                 fi

--- a/salomon.sh
+++ b/salomon.sh
@@ -128,6 +128,10 @@ else
                 highlight=1
                 shift
             ;;
+            --highlight-upper)
+                highlight_upper=1
+                shift
+            ;;
             --ignore-case)
                 arg_case="-i"
                 shift
@@ -235,9 +239,9 @@ else
             usage \
                 "The '--ignore-case' argument can only be used with a filter."
         fi
-        if [ $highlight = 1 ]; then
-        usage \
-                "The '--highlight' argument can only be used with a filter."
+        if [ $highlight = 1 ] || [ $highlight_upper = 1 ]; then
+            usage \
+                "The '--highlight' arguments can only be used with a filter."
         fi
     else
         if [ -f "$filter_pattern" ]; then


### PR DESCRIPTION
Added the additional command-line argument `--highlight-upper` to explicitly use uppercase letters when highlighting filter terms.